### PR TITLE
Dry Run & Congruence added

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,6 +4,21 @@
    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
    "version": "0.2.0",
    "configurations": [
+      {"name":"Python: Current File","type":"python","request":"launch","program":"${file}","console":"integratedTerminal","justMyCode":true},{
+         "name": "Bump dry run naibrd major",
+         "type": "python",
+         "request": "launch",
+         "program": "bumpCversion.py",
+         "console": "integratedTerminal",
+         "args": [
+            "--dry-run",
+            "--config-file",
+            "./tests/.bump.cfg",
+            "--component",
+            "naibrd",
+            "major"
+         ]
+      },
       {
          "name": "Bump naibrd major",
          "type": "python",

--- a/bumpCversion.py
+++ b/bumpCversion.py
@@ -44,7 +44,7 @@ def parse_args():
     parser.add_argument(
         "--dry-run",
         action='store_true',
-        help="Print out current and expected versions"
+        help="Print out current and expected versions (without modifying files)"
     )
     parser.add_argument(
         "part",
@@ -124,7 +124,7 @@ def valid_version_congruence(args, target_files, versions):
     while target_files:
         filetype = get_filetype_object(args, target_files)
         # add version to unique set
-        versions.add(filetype.version_number.__str__())
+        versions.add(str(filetype.version_number))
         target_files.pop(0)
 
     if len(versions) == 1:
@@ -142,10 +142,10 @@ def print_dry(args, target_files, versions):
         print("--dry-run output: ")
         if target_files:
             filetype = get_filetype_object(args, target_files)
-            print("Current version = " + str(filetype.version_number.__str__()))
+            print("Current version = " + str(filetype.version_number))
             filetype.version_number.bump(args.part, args.dont_reset)
             print("Expected version post-bump = " +
-                  str(filetype.version_number.__str__()) + "\n")
+                  str(filetype.version_number) + "\n")
 
 
 def get_filetype_object(args, target_files):
@@ -195,9 +195,6 @@ def main():
 
         # Creates object representing first file from `target_files`, then pops it off list
         filetype = get_filetype_object(args, target_files)
-
-        # Print class type (named after filetype)
-        print("Using " + type(filetype).__name__ + " class...")
 
         # Print file were working with
         print("Target file: " + target_files[0])

--- a/exceptions.py
+++ b/exceptions.py
@@ -36,3 +36,26 @@ class PreProcessorException(BaseError):
                  val,
                  message="Format of C contents incorrect. Expecting format (example): \n#define XXXXX_XXXXX_MAJOR (2U)\n#define XXXXX_XXXXX_MINOR (2U)\n#define XXXXX_XXXXX_PATCH (2U)\n"):
         super().__init__(val, message)
+
+
+class VersionException(BaseError):
+    """
+    exception thrown if versions are different across multiple files
+    """
+
+    def __init__(self,
+                 val,
+                 message="Please ensure version numbers across all included files are equal and/or exist...\n"):
+        super().__init__(val, message)
+
+class FileNotSupportedException(BaseError):
+    """
+    exception thrown if file is not implemented in filetypes.py
+    """
+
+    def __init__(self,
+                 val,
+                 message="Filetype not supported. Please implement code for desired filetype."):
+        super().__init__(val, message)
+
+        


### PR DESCRIPTION
# Dry Run
`--dry-run` will let user print expected version number without overwriting any files. This was done using pythons `argparse` module.
```python
parser.add_argument(
        "--dry-run",
        action='store_true',
        help="Print out current and expected versions"
    )
```
## Usage & Output

![image](https://user-images.githubusercontent.com/31936622/158446285-2ab901f6-e655-44f4-bed7-9468dd2df3d8.png)

# Congruence
When running bumpCversion, we want each components files (specified in `.bump.cfg`) to have the same version number _BEFORE_ bumping. We enforce this because we're manipulating data across _x_ amount of files and we wouldnt want to perform operations on imbalanced data. This would lead to unequal version numbers across multiple files.

To accomplish this we use a `set`. Note that a set is a collection that is unordered, unchangeable*, and unindexed. 
```python
def valid_version_congruence(args, target_files, versions):
    """
    Check to see if version number is the same across all files.
    """
    while target_files:
        filetype = get_filetype_object(args, target_files)
        # add version to unique set
        versions.add(filetype.version_number.__str__())
        target_files.pop(0)

    if len(versions) == 1:
        return 1
    else:
        print("Multiple Verisons Found -> " + str(versions))
        raise(VersionException(Exception))
```
The logic here is that when the  `versions` set has a length of one, we **guarantee** congruence.  


_____________________________________________________________________________________

Fixes #5 
Fixes #4 

